### PR TITLE
Make FlagCommand.signature fully format flags args.

### DIFF
--- a/discord/ext/flags/_command.py
+++ b/discord/ext/flags/_command.py
@@ -31,10 +31,23 @@ class FlagCommand(commands.Command):
         result = []
         for name, param in params.items():
             if isinstance(param.annotation, FlagParser):
-                fmt = ''
+                fmt = []
+
                 for flag_name, flag_type in param.annotation.flags.items():
-                    fmt += f'--{flag_name}={flag_type.__name__} '
-                result.append(fmt)
+                    actual_type = flag_type.__name__ if inspect.isclass(flag_type) else type(flag_type).__name__
+
+                    if actual_type == 'bool':
+                        bool_flag = '-{0}' if len(flag_name) == 1 else '--{0}'
+                        fmt.append(bool_flag.format(flag_name))
+                        continue
+                    if len(flag_name) == 1:
+                        fmt.append('-{0} {1}'.format(flag_name, actual_type))
+                        continue
+
+                    fmt.append('--{0}={1}'.format(flag_name, actual_type))
+
+                sig = ['[{0}]'.format(f) if param.default is not param.empty else '<{0}>'.format(f) for f in fmt]
+                result.append(' '.join(sig))
                 continue
 
             greedy = isinstance(param.annotation, commands.converter._Greedy)

--- a/discord/ext/flags/_command.py
+++ b/discord/ext/flags/_command.py
@@ -30,6 +30,13 @@ class FlagCommand(commands.Command):
 
         result = []
         for name, param in params.items():
+            if isinstance(param.annotation, FlagParser):
+                fmt = ''
+                for flag_name, flag_type in param.annotation.flags.items():
+                    fmt += f'--{flag_name}={flag_type.__name__} '
+                result.append(fmt)
+                continue
+
             greedy = isinstance(param.annotation, commands.converter._Greedy)
 
             try:


### PR DESCRIPTION
This PR makes FlagParser args fully format in FlagCommand.signature.

Example:
```
@bot.command(cls=flags.FlagCommand)
async def flags(ctx, foo, *, flag: flags.FlagParser(
    count = int,
    string = str,
    user = discord.User,
    thing = bool
) = flags.EmptyFlags):
    c = flag['count']
    s = flag['string']
    u = flag['user']
    t = flag['thing']

    await ctx.send(f"test: {type(foo).__name__} {foo}"
                   f"--count: {type(c).__name__} {c}\n"
                   f"--string: {type(s).__name__} {s}\n"
                   f"--user: {type(u).__name__} {u}\n"
                   f"--thing: {type(t).__name__}: {t}")
```

flags.signature will be formatted like so:
``<foo> --count=int --string=str --user=User --thing=bool``