### PR TITLE
Use _convert_to_bool function to line up with discord.py

### DIFF
--- a/discord/ext/flags/_parser.py
+++ b/discord/ext/flags/_parser.py
@@ -3,6 +3,7 @@ import sys
 
 from discord.utils import escape_mentions
 from discord.ext import commands
+from discord.ext.commands.core import _convert_to_bool
 
 from ._converters import CONVERTERS
 
@@ -35,6 +36,10 @@ class DontExitArgumentParser(argparse.ArgumentParser):
         if not callable(type_func):
             msg = '%r is not callable'
             raise argparse.ArgumentError(action, msg % type_func)
+
+        # if type is bool, use the discord.py's bool converter
+        if type_func is bool:
+            type_func = _convert_to_bool
 
         # convert the value to the appropriate type
         try:


### PR DESCRIPTION
```python
# Invocation: !flags --count=5 --string "hello world" --user Xua --thing y
```
It seems like the example given indicated that `--flag y` and `--flag n` would be converted into `True` and `False` respectively. The current implementation directly calls bool on the argument that would make `--flag n` as True. 

Use discord.py's `_convert_to_bool` function to line up with discord.py's bool conversion.